### PR TITLE
Fix problem with regex constructor

### DIFF
--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeRegExpTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeRegExpTest.java
@@ -6,6 +6,7 @@ package org.mozilla.javascript.tests.es6;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -197,6 +198,81 @@ public class NativeRegExpTest {
                                 "SyntaxError: Invalid regular expression: The quantifier maximum '1' is less than the minimum '2'.",
                                 e.getMessage());
                     }
+
+                    return null;
+                });
+    }
+
+    @Test
+    public void canCreateRegExpPassingExistingRegExp() {
+        Utils.runWithAllOptimizationLevels(
+                cx -> {
+                    ScriptableObject scope = cx.initStandardObjects();
+
+                    String source =
+                            "var pattern = /./i;\n"
+                                    + "var re = new RegExp(pattern);\n"
+                                    + "pattern.source === re.source &&"
+                                    + "  pattern.multiline === re.multiline &&"
+                                    + "  pattern.global === re.global && "
+                                    + "  pattern.ignoreCase === re.ignoreCase";
+                    assertEquals(Boolean.TRUE, cx.evaluateString(scope, source, "test", 0, null));
+
+                    return null;
+                });
+    }
+
+    @Test
+    public void canCreateRegExpPassingExistingRegExpAndUndefinedFlags() {
+        Utils.runWithAllOptimizationLevels(
+                cx -> {
+                    ScriptableObject scope = cx.initStandardObjects();
+
+                    String source =
+                            "var pattern = /./i;\n"
+                                    + "var re = new RegExp(pattern, undefined);\n"
+                                    + "pattern.source === re.source &&"
+                                    + "  pattern.multiline === re.multiline &&"
+                                    + "  pattern.global === re.global && "
+                                    + "  pattern.ignoreCase === re.ignoreCase";
+                    assertEquals(Boolean.TRUE, cx.evaluateString(scope, source, "test", 0, null));
+
+                    return null;
+                });
+    }
+
+    @Test
+    public void cannotCreateRegExpPassingExistingRegExpAndNewFlagsBeforeEs6() {
+        Utils.runWithAllOptimizationLevels(
+                cx -> {
+                    cx.setLanguageVersion(Context.VERSION_1_8);
+                    ScriptableObject scope = cx.initStandardObjects();
+
+                    String source =
+                            "var pattern = /./im;\n"
+                                    + "pattern.lastIndex = 42;\n"
+                                    + "new RegExp(pattern, \"g\");\n";
+                    assertThrows(
+                            EcmaError.class,
+                            () -> cx.evaluateString(scope, source, "test", 0, null));
+
+                    return null;
+                });
+    }
+
+    @Test
+    public void canCreateRegExpPassingExistingRegExpAndNewFlagsEs6() {
+        Utils.runWithAllOptimizationLevels(
+                cx -> {
+                    cx.setLanguageVersion(Context.VERSION_ES6);
+                    ScriptableObject scope = cx.initStandardObjects();
+
+                    String source =
+                            "var pattern = /./im;\n"
+                                    + "pattern.lastIndex = 42;\n"
+                                    + "var re = new RegExp(pattern, \"g\");\n"
+                                    + "re.global && re.lastIndex === 0";
+                    assertEquals(Boolean.TRUE, cx.evaluateString(scope, source, "test", 0, null));
 
                     return null;
                 });

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1866,7 +1866,7 @@ built-ins/Promise 429/631 (67.99%)
 
 ~built-ins/Reflect
 
-built-ins/RegExp 1174/1853 (63.36%)
+built-ins/RegExp 1169/1853 (63.09%)
     CharacterClassEscapes 24/24 (100.0%)
     dotall 4/4 (100.0%)
     escape 20/20 (100.0%)
@@ -2115,7 +2115,6 @@ built-ins/RegExp 1174/1853 (63.36%)
     regexp-modifiers/syntax/valid 8/8 (100.0%)
     regexp-modifiers 53/53 (100.0%)
     unicodeSets/generated 112/112 (100.0%)
-    15.10.4.1-1.js
     call_with_non_regexp_same_constructor.js
     call_with_regexp_match_falsy.js
     call_with_regexp_not_same_constructor.js
@@ -2135,10 +2134,6 @@ built-ins/RegExp 1174/1853 (63.36%)
     S15.10.1_A1_T14.js
     S15.10.1_A1_T15.js
     S15.10.1_A1_T16.js
-    S15.10.3.1_A2_T1.js
-    S15.10.3.1_A2_T2.js
-    S15.10.4.1_A2_T1.js
-    S15.10.4.1_A2_T2.js
     u180e.js {unsupported: [u180e]}
     unicode_character_class_backspace_escape.js
     unicode_full_case_folding.js


### PR DESCRIPTION
The spec says that we can create a new regex passing an existing one and a different set of flags, but that does not work. This PR fixes it. We also now pass a few more test262 cases.